### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -274,7 +274,7 @@ def world_map(year: int):
     base_path = os.path.join("app", "templates")
     abs_base_path = os.path.abspath(base_path)
     map_filename = f"world_map_{user_lang}.html"
-    map_path = os.path.normpath(os.path.join(base_path, str(year), map_filename))
+    map_path = os.path.realpath(os.path.normpath(os.path.join(base_path, str(year), map_filename)))
 
     # base_path からのパストラバーサル防止
     if not map_path.startswith(abs_base_path) or not os.path.commonpath([abs_base_path, map_path]) == abs_base_path:


### PR DESCRIPTION
Potential fix for [https://github.com/shumizu418128/gbbinfo2.0/security/code-scanning/6](https://github.com/shumizu418128/gbbinfo2.0/security/code-scanning/6)

To fix the issue, we need to ensure that the constructed `map_path` is safe and cannot be exploited for path traversal attacks. This involves:
1. Normalizing the constructed path using `os.path.normpath` to resolve any `..` segments or other irregularities.
2. Verifying that the normalized path starts with the absolute base path (`abs_base_path`) to ensure it is contained within the allowed directory.
3. Ensuring that the `@validate_year` decorator is not relied upon as the sole safeguard, as its implementation is not visible.

The changes will be made in the `world_map` function, specifically around the construction and validation of `map_path`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - マップデータの読み込み時のパス検証が強化され、セキュリティが向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->