### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -278,10 +278,12 @@ def world_map(year: int):
     )
 
     # base_path からのパストラバーサル防止
-    if (
-        not map_path.startswith(abs_base_path)
-        or not os.path.commonpath([abs_base_path, map_path]) == abs_base_path
-    ):
+    try:
+        # Ensure map_path is strictly within abs_base_path
+        if os.path.commonpath([abs_base_path, map_path]) != abs_base_path:
+            abort(404)
+    except ValueError:
+        # Handle invalid paths that could cause os.path.commonpath to fail
         abort(404)
 
     if not os.path.exists(map_path):


### PR DESCRIPTION
Potential fix for [https://github.com/shumizu418128/gbbinfo2.0/security/code-scanning/6](https://github.com/shumizu418128/gbbinfo2.0/security/code-scanning/6)

To fix the issue, we will:
1. Normalize the constructed path (`map_path`) using `os.path.realpath` to resolve any symbolic links and remove `..` segments.
2. Ensure that the normalized path is strictly contained within the intended base directory (`abs_base_path`) by using `os.path.commonpath`.
3. Add a fallback mechanism to handle invalid paths by raising a `404` error if the path validation fails.

This approach ensures that even if the `year` parameter is manipulated, the resulting path cannot escape the intended directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - マップ表示時のパス検証方法を改善し、不正なパス指定によるエラー時に適切に404エラーを返すようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->