### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Lighthouse
 on: [pull_request]
+permissions:
+  contents: read
 
 jobs:
   lighthouse:


### PR DESCRIPTION
Potential fix for [https://github.com/shumizu418128/gbbinfo2.0/security/code-scanning/22](https://github.com/shumizu418128/gbbinfo2.0/security/code-scanning/22)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow appears to perform a Lighthouse check using the `foo-software/lighthouse-check-action`, it likely only requires read access to the repository contents. We will add a `permissions` block at the root of the workflow to apply these minimal permissions to all jobs. This ensures the workflow adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
